### PR TITLE
Fix DSL for Ember 2.8

### DIFF
--- a/addon/dsl.js
+++ b/addon/dsl.js
@@ -10,27 +10,24 @@ export function setup() {
     _buildDSL() {
       let moduleBasedResolver = this._hasModuleBasedResolver();
       let owner = getOwner(this);
+      let router = this;
 
       let options = {
         owner: owner,
         enableLoadingSubstates: !!moduleBasedResolver
       };
 
-      if (isEnabled('ember-application-engines')) {
-        let router = this;
+      options.enableLoadingSubstates = !!moduleBasedResolver;
 
-        options.enableLoadingSubstates = !!moduleBasedResolver;
+      options.resolveRouteMap = function(name) {
+        return owner._lookupFactory('route-map:' + name);
+      };
 
-        options.resolveRouteMap = function(name) {
-          return owner._lookupFactory('route-map:' + name);
-        };
-
-        options.addRouteForEngine = function(name, engineInfo) {
-          if (!router._engineInfoByRoute[name]) {
-            router._engineInfoByRoute[name] = engineInfo;
-          }
-        };
-      }
+      options.addRouteForEngine = function(name, engineInfo) {
+        if (!router._engineInfoByRoute[name]) {
+          router._engineInfoByRoute[name] = engineInfo;
+        }
+      };
 
       return new Ember.RouterDSL(null, options);
     }


### PR DESCRIPTION
In Ember 2.8 engines are enabled and removed from features.json. isEnabled now returns undefined which is incorrect for 2.8+ use cases.
